### PR TITLE
Add additional Trove classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,10 @@ packages = [
     { include = "ansible_pygments", from = "src" },
     { include = "tests", format = "sdist" }
 ]
+classifiers = [
+    "Development Status :: 6 - Mature",
+    "Intended Audience :: Developers"
+]
 
 [tool.poetry.plugins."pygments.lexers"]
 Ansible-output = "ansible_pygments.lexers:AnsibleOutputLexer"


### PR DESCRIPTION
License and Python classifiers are already there, see https://test.pypi.org/project/ansible-pygments/.

Fixes #18.