### PR TITLE
Switch build-backend to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry-core>=0.12"]
+requires = ["poetry-core>=1.0.7"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=0.12"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ansible-pygments"


### PR DESCRIPTION
Use poetry-core rather than poetry in pyproject.toml.  The former
is recommended for PEP 517 builds as it brings a smaller subset
of poetry modules needed to perform the build without all
the dependencies of the poetry package manager.  This makes builds much
faster.