### PR TITLE
Exclude pypy-3.6 on macOS from CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -396,6 +396,8 @@ jobs:
         exclude:
         - os: Windows
           python-version: pypy-3.6
+        - os: macOS
+          python-version: pypy-3.6
 
     continue-on-error: >-
       ${{


### PR DESCRIPTION
Let's see whether this is the only problem. It also was already disabled for Windows.