### PR TITLE
Switch to new codecov action version

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -490,7 +490,7 @@ jobs:
         --skip-missing-interpreters false
         --skip-pkg-install
     - name: Send coverage data to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         file: .test-results/pytest/cov.xml
         flags: >-


### PR DESCRIPTION
The old version has been deprecated and no longer works:
https://github.com/codecov/codecov-action/tree/b049ab51f46ef6cd9c7ca52a856631a818969c7c#%EF%B8%8F--deprecration-of-v1