### PR TITLE
🔧 Make isort aware of the framework & testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,21 @@ pygments = ">= 2.11.0"
 balanced_wrapping = true
 include_trailing_comma = true
 indent = 4
+known_first_party = 'ansible_pygments'
+known_framework = 'pygments'
+known_testing = ['pytest', 'unittest']
 # Should be: 80 - 1
 line_length = 79
 # https://github.com/timothycrosley/isort#multi-line-output-modes
 multi_line_output = 5
+no_lines_before = 'LOCALFOLDER'
+sections = [
+    'FUTURE',
+    'STDLIB',
+    'FRAMEWORK',
+    'TESTING',
+    'THIRDPARTY',
+    'FIRSTPARTY',
+    'LOCALFOLDER',
+]
 use_parentheses = true


### PR DESCRIPTION
This patch makes sure that the main runtime framework (`pygments`) and the testing framework (`pytest`) are placed in dedicated import locations.