### PR TITLE
🧪🐛 Drop artifact name from coverage flags

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -735,8 +735,7 @@ jobs:
           }},
           Py-${{
             steps.python-install.outputs.python-version
-          }},
-          ${{ env.ARTIFACT_NAME }}
+          }}
 
   check:  # This job does nothing and is only used for the branch protection
     if: always()


### PR DESCRIPTION
Apparently, codecov does not accept things like `+` and the CI step succeeds silently.