### PR TITLE
🧪 Teach coveragepy merge PyPy toxenv paths

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,7 @@ source =
   src/ansible_pygments
   */src/ansible_pygments
   .tox/*/lib/python*/site-packages/ansible_pygments
+  .tox/*/lib/pypy*/site-packages/ansible_pygments
 
 [report]
 skip_covered = true


### PR DESCRIPTION
Previously, it separated project-local from venv paths for PyPy but not for CPython runs because the wildcard path in `.coveragerc` didn't take it into account. Now it does.