### PR TITLE
Require Python 3.9+; add Python 3.12 and 3.13 to CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -505,13 +505,15 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
+        # Highest, lowest, and pypy should come first:
         - 3.13
+        - 3.9
+        - pypy-3.9
+        # Then all other versions:
         - 3.12
         - 3.11
         - >-
           3.10
-        - pypy-3.9
-        - 3.9
         tested-artifact:
         - wheel
         - sdist

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -56,7 +56,6 @@ env:
   PRE_COMMIT_COLOR: always
   PY_COLORS: 1  # Recognized by the `py` package, dependency of `pytest`
   PYTHONIOENCODING: utf-8
-  PYTHONLEGACYWINDOWSSTDIO: 1  # Python 3.6 hack
   PYTHONUTF8: 1
   TOX_PARALLEL_NO_SPINNER: 1
   TOX_TESTENV_PASSENV: >-  # Make tox-wrapped tools see color requests
@@ -84,7 +83,7 @@ jobs:
         os:
         - Ubuntu
         python-version:
-        - 3.11
+        - 3.13
 
     env:
       TOXENV: lint
@@ -191,10 +190,10 @@ jobs:
       sdist-artifact-name: ${{ steps.artifact-name.outputs.sdist }}
       wheel-artifact-name: ${{ steps.artifact-name.outputs.wheel }}
     steps:
-    - name: Switch to using Python 3.11 by default
+    - name: Switch to using Python 3.13 by default
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.13
     - name: >-
         Mark the build as non-tagged
         ${{ github.event.repository.default_branch }} build
@@ -396,10 +395,10 @@ jobs:
       TOXENV: cleanup-dists,build-dists,metadata-validation
 
     steps:
-    - name: Switch to using Python 3.11 by default
+    - name: Switch to using Python 3.13 by default
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.13
     - name: >-
         Calculate Python interpreter version hash value
         for use in the cache key
@@ -506,33 +505,16 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
+        - 3.13
+        - 3.12
         - 3.11
-        - pypy-3.9
-        - 3.8
-        - 3.7
-        - 3.9
         - >-
           3.10
-        - pypy-3.6
-        - ~3.12.0-0
+        - pypy-3.9
+        - 3.9
         tested-artifact:
         - wheel
         - sdist
-        exclude:
-        # NOTE: PyPy 3.6 is not built for Ubuntu 22
-        - os: windows-latest
-          python-version: pypy-3.6
-        - os: macos-latest
-          python-version: pypy-3.6
-        # CPython 3.7 is no longer available on macos-latest
-        - os: macos-latest
-          python-version: 3.7
-        include:
-        # NOTE: The last GNU/Linux CPython 3.6 available is built for Ubuntu 20
-        # https://github.com/actions/python-versions/blob/6dd0b75/versions-manifest.json#L3956-L3960
-        - os: ubuntu-20.04
-          python-version: 3.6
-          tested-artifact: wheel
 
     continue-on-error: >-
       ${{

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ Ansible = "ansible_pygments.styles:AnsibleStyle"
 ansible = "ansible_pygments.styles:AnsibleStyle"
 
 [tool.poetry.dependencies]
-python = "^3.9.0"
+python = ">= 3.9.0"
 # Pygments 2.4.0 includes bugfixes for YAML and YAML+Jinja lexers
 pygments = ">= 2.4.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ Ansible = "ansible_pygments.styles:AnsibleStyle"
 ansible = "ansible_pygments.styles:AnsibleStyle"
 
 [tool.poetry.dependencies]
-python = "^3.6.0"
+python = "^3.9.0"
 # Pygments 2.4.0 includes bugfixes for YAML and YAML+Jinja lexers
 pygments = ">= 2.4.0"
 

--- a/src/ansible_pygments/lexers.py
+++ b/src/ansible_pygments/lexers.py
@@ -34,6 +34,8 @@
 
 """Pygments lexers for ansible console output."""
 
+from __future__ import annotations
+
 # pylint: disable=consider-using-f-string
 
 from pygments import token

--- a/src/ansible_pygments/lexers.py
+++ b/src/ansible_pygments/lexers.py
@@ -36,11 +36,11 @@
 
 from __future__ import annotations
 
-# pylint: disable=consider-using-f-string
-
 from pygments import token
 from pygments.lexer import DelegatingLexer, RegexLexer, bygroups, include
 from pygments.lexers import DiffLexer  # pylint: disable=no-name-in-module
+
+# pylint: disable=consider-using-f-string
 
 
 class AnsibleOutputPrimaryLexer(RegexLexer):

--- a/src/ansible_pygments/lexers.py
+++ b/src/ansible_pygments/lexers.py
@@ -34,8 +34,6 @@
 
 """Pygments lexers for ansible console output."""
 
-from __future__ import annotations
-
 from pygments import token
 from pygments.lexer import DelegatingLexer, RegexLexer, bygroups, include
 from pygments.lexers import DiffLexer  # pylint: disable=no-name-in-module

--- a/src/ansible_pygments/lexers.py
+++ b/src/ansible_pygments/lexers.py
@@ -32,13 +32,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# pylint: disable=consider-using-f-string
+
 """Pygments lexers for ansible console output."""
 
 from pygments import token
 from pygments.lexer import DelegatingLexer, RegexLexer, bygroups, include
 from pygments.lexers import DiffLexer  # pylint: disable=no-name-in-module
-
-# pylint: disable=consider-using-f-string
 
 
 class AnsibleOutputPrimaryLexer(RegexLexer):

--- a/src/ansible_pygments/styles.py
+++ b/src/ansible_pygments/styles.py
@@ -1,5 +1,7 @@
 """Pygments styles for highlighting snippets in Ansible ecosystem."""
 
+from __future__ import annotations
+
 from pygments.style import Style
 from pygments.token import (
     Comment, Error, Generic, Keyword, Literal, Name,

--- a/src/ansible_pygments/styles.py
+++ b/src/ansible_pygments/styles.py
@@ -1,7 +1,5 @@
 """Pygments styles for highlighting snippets in Ansible ecosystem."""
 
-from __future__ import annotations
-
 from pygments.style import Style
 from pygments.token import (
     Comment, Error, Generic, Keyword, Literal, Name,


### PR DESCRIPTION
We soon [cannot use GHA's ubuntu-20.04 image any more](https://forum.ansible.com/t/40187), so we won't be able to test on Python 3.6 anymore. My suggestion is to drop support for all Python versions < 3.9 while we're at it, and release 0.2.0.